### PR TITLE
[PHP 8.0] Invoke.php: fix deprecation notices

### DIFF
--- a/src/Invoke.php
+++ b/src/Invoke.php
@@ -14,7 +14,7 @@ use ArrayAccess;
  *
  * @return mixed
  */
-function ifCondition(callable $callable, $methodArguments = [], $condition)
+function ifCondition(callable $callable, $methodArguments = [], $condition = false)
 {
     if (true === $condition) {
         return call_user_func_array(


### PR DESCRIPTION
PHP 8 deprecated required declaring functions/methods that have optional parameters before required ones.